### PR TITLE
Added a Allocation#for_job API

### DIFF
--- a/lib/nomad/api/allocation.rb
+++ b/lib/nomad/api/allocation.rb
@@ -32,6 +32,18 @@ module Nomad
       json = client.get("/v1/allocation/#{CGI.escape(id)}", options)
       return Alloc.decode(json)
     end
+
+    # Read all allocations for a given job
+    #
+    # @param [String] job_id The Job ID of the job
+    #
+    # @return Array<Alloc>
+    def for_job(job_id, **options)
+      json = client.get("/v1/job/#{CGI.escape(job_id)}/allocations", options)
+      return json.map do |alloc_json|
+        Alloc.decode(alloc_json)
+      end
+    end
   end
 
   class Alloc < Response

--- a/spec/integration/api/allocation_spec.rb
+++ b/spec/integration/api/allocation_spec.rb
@@ -69,5 +69,15 @@ module Nomad
         expect(result.task_states).to be_a(Hash)
       end
     end
+
+    describe "#for_job" do
+      it "reads allocations for a specific job" do
+        result = subject.for_job "job"
+        expect(result).to be
+        expect(result).to be_a(Array)
+        expect(result.count).to eq(3)
+        expect(result.first).to be_a(Alloc)
+      end
+    end
   end
 end


### PR DESCRIPTION
Added a simple API to `Allocation` to fetch all allocs for a given job, wrapping the `/v1/job/<ID>/allocations` API endpoint.

An API like
```
Nomad.job('my_job').allocations
```
would probably be nicer, however a `Response` doesn't have access to the Client at this point, enabling an ABI like this would require a few more changes. 